### PR TITLE
Unittests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ REQUIRES_PYTHON = ">=3.6.0"
 VERSION = "0.1.6"
 
 # What packages are required for this module to be executed?
-REQUIRED = ["numpy", "torch", "torchaudio", "wavaugment"]
+REQUIRED = ["numpy", "torch", "torchaudio", "julius", "wavaugment"]
 
 # What packages are optional?
 EXTRAS = {
-    'fancy feature': ['essentia'],
+    'fancy feature': [''],
 }
 
 # The rest you shouldn't have to touch too much :)

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1,125 +1,127 @@
 import numpy as np
 import torch
 import torchaudio
-import unittest
+import pytest
 
-from torchaudio_augmentations import *
+from torchaudio_augmentations import Compose, RandomResizedCrop, PolarityInversion, Noise, Gain, HighLowPass, Delay, PitchShift, Reverb, Reverse
+from .utils import generate_waveform
 
 
-class TestShapes(unittest.TestCase):
+sample_rate = 22050
+num_samples = sample_rate * 5
 
-    def setUp(self):
-        self.sr = 22050
-        self.num_samples = self.sr * 5
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_random_resized_crop(num_channels):
+    num_samples = 22050 * 5
+    audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose([RandomResizedCrop(num_samples)])
 
-    def stereo_waveform(self, num_samples):
+    audio = transform(audio)
+    assert audio.shape[0] == num_channels
+    assert audio.shape[1] == num_samples
 
-        # Dividing x legnth value into three parts:- 1/10, 1/2, 4/10.
-        attack_length = num_samples // 10
-        decay_length = num_samples // 2
-        sustain_length = num_samples - (attack_length + decay_length)
-        sustain_value = 0.1   # Release amplitude between 0 and  1
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_polarity(num_channels):
+    audio = generate_waveform(sample_rate, num_samples,
+                              num_channels=num_channels)
+    transform = Compose(
+        [PolarityInversion()],
+    )
 
-        # Setting array size and length.
-        attack = np.linspace(0, 1, num=attack_length)
-        decay = np.linspace(1, sustain_value, num=decay_length)
-        sustain = np.ones(sustain_length) * sustain_value
-        attack_decay_sustain = np.concatenate((attack, decay, sustain))
+    t_audio = transform(audio)
+    assert (t_audio == torch.neg(audio)).all()
+    assert t_audio.shape == audio.shape
 
-        freq = 440
-        wavedata = np.sin(2 * np.pi * np.arange(num_samples)
-                          * freq / self.sr)
 
-        wavedata = wavedata * attack_decay_sustain
-        wavedata = np.array([wavedata, wavedata * 0.9]).astype(np.float32)
-        return torch.from_numpy(wavedata).reshape(2, -1)
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_filter(num_channels):
+    audio, sr = torchaudio.load("/Users/janne/Desktop/givin_up.mp3")
+    audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose(
+        [HighLowPass(sample_rate=sample_rate)],
+    )
+    t_audio = transform(audio)
+    torchaudio.save("tests/filter.wav", t_audio, sample_rate=sample_rate)
+    assert t_audio.shape == audio.shape
 
-    def test_polarity(self):
-        audio = self.stereo_waveform(self.num_samples)
-        transform = Compose(
-            [PolarityInversion()],
-        )
 
-        t_audio = transform(audio)
-        assert (t_audio == torch.neg(audio)).all()
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_delay(num_channels):
+    audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose(
+        [Delay(sample_rate=sample_rate)],
+    )
 
-        assert t_audio.shape == audio.shape
+    t_audio = transform(audio)
+    # torchaudio.save("tests/delay.wav", t_audio, sample_rate=sample_rate)
+    assert t_audio.shape == audio.shape
 
-    def test_filter(self):
-        audio = self.stereo_waveform(self.num_samples)
-        transform = Compose(
-            [HighLowPass(sample_rate=self.sr)],
-        )
-        t_audio = transform(audio)
-        # torchaudio.save("tests/filter.wav", t_audio, sample_rate=self.sr)
-        assert t_audio.shape == audio.shape
 
-    def test_delay(self):
-        audio = self.stereo_waveform(self.num_samples)
-        transform = Compose(
-            [Delay(self.sr)],
-        )
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_gain(num_channels):
+    audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose(
+        [Gain()],
+    )
 
-        t_audio = transform(audio)
-        # torchaudio.save("tests/delay.wav", t_audio, sample_rate=self.sr)
-        assert t_audio.shape == audio.shape
+    t_audio = transform(audio)
+    # torchaudio.save("tests/gain.wav", t_audio, sample_rate=sample_rate)
+    assert t_audio.shape == audio.shape
 
-    def test_gain(self):
-        audio = self.stereo_waveform(self.num_samples)
-        transform = Compose(
-            [Gain()],
-        )
 
-        t_audio = transform(audio)
-        # torchaudio.save("tests/gain.wav", t_audio, sample_rate=self.sr)
-        assert t_audio.shape == audio.shape
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_noise(num_channels):
+    audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose(
+        [Noise(min_snr=0.5, max_snr=1)],
+    )
 
-    def test_noise(self):
-        audio = self.stereo_waveform(self.num_samples)
-        transform = Compose(
-            [Noise(min_snr=0.5, max_snr=1)],
-        )
+    t_audio = transform(audio)
+    # torchaudio.save("tests/noise.wav", t_audio, sample_rate=sample_rate)
+    assert t_audio.shape == audio.shape
 
-        t_audio = transform(audio)
-        # torchaudio.save("tests/noise.wav", t_audio, sample_rate=self.sr)
-        assert t_audio.shape == audio.shape
 
-    def test_pitch(self):
-        audio = self.stereo_waveform(self.num_samples)
-        transform = Compose(
-            [PitchShift(n_samples=self.num_samples, sample_rate=self.sr)],
-        )
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_pitch(num_channels):
+    audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose(
+        [PitchShift(n_samples=num_samples, sample_rate=sample_rate)],
+    )
 
-        t_audio = transform(audio)
-        # torchaudio.save("tests/pitch.wav", t_audio, sample_rate=sr)
-        assert t_audio.shape == audio.shape
+    t_audio = transform(audio)
+    # torchaudio.save("tests/pitch.wav", t_audio, sample_rate=sample_rate)
+    assert t_audio.shape == audio.shape
 
-    def test_reverb(self):
-        audio = self.stereo_waveform(self.num_samples)
-        transform = Compose(
-            [Reverb(self.sr)],
-        )
 
-        t_audio = transform(audio)
-        # torchaudio.save("tests/reverb.wav", t_audio, sample_rate=sr)
-        assert t_audio.shape == audio.shape
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_reverb(num_channels):
+    audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose(
+        [Reverb(sample_rate=sample_rate)],
+    )
 
-    def test_reverse(self):
-        stereo_audio = self.stereo_waveform(self.num_samples)
-        transform = Compose(
-            [Reverse()],
-        )
+    t_audio = transform(audio)
+    # torchaudio.save("tests/reverb.wav", t_audio, sample_rate=sample_rate)
+    assert t_audio.shape == audio.shape
 
-        t_audio = transform(stereo_audio)
-        # torchaudio.save("tests/reverse.wav", t_audio, sample_rate=self.sr)
 
-        reversed_single_channel = torch.flip(t_audio, [1])[0]
-        assert torch.equal(reversed_single_channel, stereo_audio[0]) == True
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_reverse(num_channels):
+    stereo_audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose(
+        [Reverse()],
+    )
 
-        reversed_stereo_channel = torch.flip(t_audio, [0])[0]
-        assert torch.equal(reversed_stereo_channel, stereo_audio[0]) == False
+    t_audio = transform(stereo_audio)
+    # torchaudio.save("tests/reverse.wav", t_audio, sample_rate=sample_rate)
 
-        assert t_audio.shape == stereo_audio.shape
+    reversed_single_channel = torch.flip(t_audio, [1])[0]
+    assert torch.equal(reversed_single_channel, stereo_audio[0]) == True
 
-        mono_audio = stereo_audio.mean(dim=0)
-        assert mono_audio.shape[0] == stereo_audio.shape[1]
+    reversed_stereo_channel = torch.flip(t_audio, [0])[0]
+    assert torch.equal(reversed_stereo_channel, stereo_audio[0]) == False
+
+    assert t_audio.shape == stereo_audio.shape
+
+    mono_audio = stereo_audio.mean(dim=0)
+    assert mono_audio.shape[0] == stereo_audio.shape[1]

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -3,14 +3,26 @@ import torch
 import torchaudio
 import pytest
 
-from torchaudio_augmentations import Compose, RandomResizedCrop, PolarityInversion, Noise, Gain, HighLowPass, Delay, PitchShift, Reverb, Reverse
+from torchaudio_augmentations import (
+    Compose,
+    RandomResizedCrop,
+    PolarityInversion,
+    Noise,
+    Gain,
+    HighLowPass,
+    Delay,
+    PitchShift,
+    Reverb,
+    Reverse,
+)
 from .utils import generate_waveform
 
 
 sample_rate = 22050
 num_samples = sample_rate * 5
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_random_resized_crop(num_channels):
     num_samples = 22050 * 5
     audio = generate_waveform(sample_rate, num_samples, num_channels)
@@ -20,97 +32,81 @@ def test_random_resized_crop(num_channels):
     assert audio.shape[0] == num_channels
     assert audio.shape[1] == num_samples
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_polarity(num_channels):
-    audio = generate_waveform(sample_rate, num_samples,
-                              num_channels=num_channels)
-    transform = Compose(
-        [PolarityInversion()],
-    )
+    audio = generate_waveform(sample_rate, num_samples, num_channels=num_channels)
+    transform = Compose([PolarityInversion()],)
 
     t_audio = transform(audio)
     assert (t_audio == torch.neg(audio)).all()
     assert t_audio.shape == audio.shape
 
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_filter(num_channels):
     audio, sr = torchaudio.load("/Users/janne/Desktop/givin_up.mp3")
-    audio = generate_waveform(sample_rate, num_samples, num_channels)
-    transform = Compose(
-        [HighLowPass(sample_rate=sample_rate)],
-    )
+    # audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose([HighLowPass(sample_rate=sr)],)
     t_audio = transform(audio)
-    torchaudio.save("tests/filter.wav", t_audio, sample_rate=sample_rate)
+    torchaudio.save("tests/filter.wav", t_audio, sample_rate=sr)
     assert t_audio.shape == audio.shape
 
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_delay(num_channels):
     audio = generate_waveform(sample_rate, num_samples, num_channels)
-    transform = Compose(
-        [Delay(sample_rate=sample_rate)],
-    )
+    transform = Compose([Delay(sample_rate=sample_rate)],)
 
     t_audio = transform(audio)
     # torchaudio.save("tests/delay.wav", t_audio, sample_rate=sample_rate)
     assert t_audio.shape == audio.shape
 
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_gain(num_channels):
     audio = generate_waveform(sample_rate, num_samples, num_channels)
-    transform = Compose(
-        [Gain()],
-    )
+    transform = Compose([Gain()],)
 
     t_audio = transform(audio)
     # torchaudio.save("tests/gain.wav", t_audio, sample_rate=sample_rate)
     assert t_audio.shape == audio.shape
 
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_noise(num_channels):
     audio = generate_waveform(sample_rate, num_samples, num_channels)
-    transform = Compose(
-        [Noise(min_snr=0.5, max_snr=1)],
-    )
+    transform = Compose([Noise(min_snr=0.5, max_snr=1)],)
 
     t_audio = transform(audio)
     # torchaudio.save("tests/noise.wav", t_audio, sample_rate=sample_rate)
     assert t_audio.shape == audio.shape
 
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_pitch(num_channels):
     audio = generate_waveform(sample_rate, num_samples, num_channels)
-    transform = Compose(
-        [PitchShift(n_samples=num_samples, sample_rate=sample_rate)],
-    )
+    transform = Compose([PitchShift(n_samples=num_samples, sample_rate=sample_rate)],)
 
     t_audio = transform(audio)
     # torchaudio.save("tests/pitch.wav", t_audio, sample_rate=sample_rate)
     assert t_audio.shape == audio.shape
 
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_reverb(num_channels):
     audio = generate_waveform(sample_rate, num_samples, num_channels)
-    transform = Compose(
-        [Reverb(sample_rate=sample_rate)],
-    )
+    transform = Compose([Reverb(sample_rate=sample_rate)],)
 
     t_audio = transform(audio)
     # torchaudio.save("tests/reverb.wav", t_audio, sample_rate=sample_rate)
     assert t_audio.shape == audio.shape
 
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_reverse(num_channels):
     stereo_audio = generate_waveform(sample_rate, num_samples, num_channels)
-    transform = Compose(
-        [Reverse()],
-    )
+    transform = Compose([Reverse()],)
 
     t_audio = transform(stereo_audio)
     # torchaudio.save("tests/reverse.wav", t_audio, sample_rate=sample_rate)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -7,30 +7,23 @@ sample_rate = 22050
 num_samples = sample_rate * 5
 
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_compose(num_channels):
     audio = generate_waveform(sample_rate, num_samples, num_channels)
-    transform = Compose(
-        [
-            RandomResizedCrop(num_samples),
-        ]
-    )
+    transform = Compose([RandomResizedCrop(num_samples),])
 
     t_audio = transform(audio)
     assert t_audio.shape[0] == num_channels
     assert t_audio.shape[1] == num_samples
 
 
-@pytest.mark.parametrize('num_channels', [1, 2])
+@pytest.mark.parametrize("num_channels", [1, 2])
 def test_compose_many(num_channels):
     num_augmented_samples = 10
 
     audio = generate_waveform(sample_rate, num_samples, num_channels)
     transform = ComposeMany(
-        [
-            RandomResizedCrop(num_samples),
-        ],
-        num_augmented_samples=num_augmented_samples,
+        [RandomResizedCrop(num_samples),], num_augmented_samples=num_augmented_samples,
     )
 
     t_audio = transform(audio)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,19 +1,31 @@
-import torch
-import numpy as np
-from torchaudio_augmentations import Compose, ComposeMany
-from torchaudio_augmentations import RandomResizedCrop
+import pytest
+from torchaudio_augmentations import Compose, ComposeMany, RandomResizedCrop
+
+from .utils import generate_waveform
+
+sample_rate = 22050
+num_samples = sample_rate * 5
 
 
-def random_waveform(num_samples):
-    return torch.from_numpy(np.arange(num_samples)).reshape(1, -1)
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_compose(num_channels):
+    audio = generate_waveform(sample_rate, num_samples, num_channels)
+    transform = Compose(
+        [
+            RandomResizedCrop(num_samples),
+        ]
+    )
+
+    t_audio = transform(audio)
+    assert t_audio.shape[0] == num_channels
+    assert t_audio.shape[1] == num_samples
 
 
-def test_compose_many():
+@pytest.mark.parametrize('num_channels', [1, 2])
+def test_compose_many(num_channels):
     num_augmented_samples = 10
 
-    num_samples = 22050 * 5
-    audio = random_waveform(num_samples)
-
+    audio = generate_waveform(sample_rate, num_samples, num_channels)
     transform = ComposeMany(
         [
             RandomResizedCrop(num_samples),
@@ -21,14 +33,7 @@ def test_compose_many():
         num_augmented_samples=num_augmented_samples,
     )
 
-    audios = transform(audio)
-    assert audios.shape[0] == num_augmented_samples
-
-
-def test_random_resized_crop():
-    num_samples = 22050 * 5
-    audio = random_waveform(num_samples)
-    transform = Compose([RandomResizedCrop(num_samples)])
-
-    audio = transform(audio)
-    assert audio.shape[1] == num_samples
+    t_audio = transform(audio)
+    assert t_audio.shape[0] == num_augmented_samples
+    assert t_audio.shape[1] == num_channels
+    assert t_audio.shape[2] == num_samples

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -1,7 +1,7 @@
 import torch
 import torchaudio
 import numpy as np
-from torchaudio_augmentations import *
+from torchaudio_augmentations import Compose, RandomResizedCrop, RandomApply, PolarityInversion, Noise, Gain, HighLowPass, Delay, PitchShift, Reverb
 
 sr = 22050
 

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -1,15 +1,25 @@
 import torch
 import torchaudio
 import numpy as np
-from torchaudio_augmentations import Compose, RandomResizedCrop, RandomApply, PolarityInversion, Noise, Gain, HighLowPass, Delay, PitchShift, Reverb
+from torchaudio_augmentations import (
+    Compose,
+    RandomResizedCrop,
+    RandomApply,
+    PolarityInversion,
+    Noise,
+    Gain,
+    HighLowPass,
+    Delay,
+    PitchShift,
+    Reverb,
+)
 
 sr = 22050
 
 
 def sine(num_samples, sr):
     freq = 440
-    sine = np.sin(2 * np.pi * np.arange(num_samples)
-                  * freq / sr).astype(np.float32)
+    sine = np.sin(2 * np.pi * np.arange(num_samples) * freq / sr).astype(np.float32)
     return torch.from_numpy(sine).reshape(1, -1)
 
 
@@ -23,11 +33,8 @@ def test_readme_example():
         RandomApply([Gain()], p=0.2),
         RandomApply([HighLowPass(sample_rate=sr)], p=0.8),
         RandomApply([Delay(sample_rate=sr)], p=0.5),
-        RandomApply([PitchShift(
-            n_samples=num_samples,
-            sample_rate=sr
-        )], p=0.4),
-        RandomApply([Reverb(sample_rate=sr)], p=0.3)
+        RandomApply([PitchShift(n_samples=num_samples, sample_rate=sr)], p=0.4),
+        RandomApply([Reverb(sample_rate=sr)], p=0.3),
     ]
 
     transform = Compose(transforms=transforms)

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -1,0 +1,35 @@
+import torch
+import torchaudio
+import numpy as np
+from torchaudio_augmentations import *
+
+sr = 22050
+
+
+def sine(num_samples, sr):
+    freq = 440
+    sine = np.sin(2 * np.pi * np.arange(num_samples)
+                  * freq / sr).astype(np.float32)
+    return torch.from_numpy(sine).reshape(1, -1)
+
+
+def test_readme_example():
+    num_samples = sr * 5
+    audio = sine(num_samples, sr)
+    transforms = [
+        RandomResizedCrop(n_samples=num_samples),
+        RandomApply([PolarityInversion()], p=0.8),
+        RandomApply([Noise(min_snr=0.3, max_snr=0.5)], p=0.3),
+        RandomApply([Gain()], p=0.2),
+        RandomApply([HighLowPass(sample_rate=sr)], p=0.8),
+        RandomApply([Delay(sample_rate=sr)], p=0.5),
+        RandomApply([PitchShift(
+            n_samples=num_samples,
+            sample_rate=sr
+        )], p=0.4),
+        RandomApply([Reverb(sample_rate=sr)], p=0.3)
+    ]
+
+    transform = Compose(transforms=transforms)
+    transformed_audio = transform(audio)
+    assert transformed_audio.shape[0] == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,27 @@
+import numpy as np
+import torch
+
+
+def generate_waveform(sample_rate: int, num_samples: int, num_channels: int) -> torch.Tensor:
+
+    # Dividing x legnth value into three parts:- 1/10, 1/2, 4/10.
+    attack_length = num_samples // 10
+    decay_length = num_samples // 2
+    sustain_length = num_samples - (attack_length + decay_length)
+    sustain_value = 0.1   # Release amplitude between 0 and  1
+
+    # Setting array size and length.
+    attack = np.linspace(0, 1, num=attack_length)
+    decay = np.linspace(1, sustain_value, num=decay_length)
+    sustain = np.ones(sustain_length) * sustain_value
+    attack_decay_sustain = np.concatenate((attack, decay, sustain))
+
+    freq = 440
+    wavedata = np.sin(2 * np.pi * np.arange(num_samples)
+                        * freq / sample_rate)
+
+    wavedata = wavedata * attack_decay_sustain
+
+    if num_channels == 2:
+        wavedata = np.array([wavedata, wavedata * 0.9])
+    return torch.from_numpy(wavedata.astype(np.float32)).reshape(num_channels, -1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,13 +2,15 @@ import numpy as np
 import torch
 
 
-def generate_waveform(sample_rate: int, num_samples: int, num_channels: int) -> torch.Tensor:
+def generate_waveform(
+    sample_rate: int, num_samples: int, num_channels: int
+) -> torch.Tensor:
 
     # Dividing x legnth value into three parts:- 1/10, 1/2, 4/10.
     attack_length = num_samples // 10
     decay_length = num_samples // 2
     sustain_length = num_samples - (attack_length + decay_length)
-    sustain_value = 0.1   # Release amplitude between 0 and  1
+    sustain_value = 0.1  # Release amplitude between 0 and  1
 
     # Setting array size and length.
     attack = np.linspace(0, 1, num=attack_length)
@@ -17,8 +19,7 @@ def generate_waveform(sample_rate: int, num_samples: int, num_channels: int) -> 
     attack_decay_sustain = np.concatenate((attack, decay, sustain))
 
     freq = 440
-    wavedata = np.sin(2 * np.pi * np.arange(num_samples)
-                        * freq / sample_rate)
+    wavedata = np.sin(2 * np.pi * np.arange(num_samples) * freq / sample_rate)
 
     wavedata = wavedata * attack_decay_sustain
 

--- a/torchaudio_augmentations/apply.py
+++ b/torchaudio_augmentations/apply.py
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 
-# Copyright (c) Soumith Chintala 2016, 
+# Copyright (c) Soumith Chintala 2016,
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import torch
+
 
 class RandomApply(torch.nn.Module):
     """Apply randomly a list of transformations with a given probability.
@@ -63,10 +64,10 @@ class RandomApply(torch.nn.Module):
         return img
 
     def __repr__(self):
-        format_string = self.__class__.__name__ + '('
-        format_string += '\n    p={}'.format(self.p)
+        format_string = self.__class__.__name__ + "("
+        format_string += "\n    p={}".format(self.p)
         for t in self.transforms:
-            format_string += '\n'
-            format_string += '    {0}'.format(t)
-        format_string += '\n)'
+            format_string += "\n"
+            format_string += "    {0}".format(t)
+        format_string += "\n)"
         return format_string

--- a/torchaudio_augmentations/augmentations/delay.py
+++ b/torchaudio_augmentations/augmentations/delay.py
@@ -4,7 +4,14 @@ import torch
 
 
 class Delay(torch.nn.Module):
-    def __init__(self, sample_rate, volume_factor=0.5, min_delay=200, max_delay=500, delay_interval=50):
+    def __init__(
+        self,
+        sample_rate,
+        volume_factor=0.5,
+        min_delay=200,
+        max_delay=500,
+        delay_interval=50,
+    ):
         super().__init__()
         self.sample_rate = sample_rate
         self.volume_factor = volume_factor

--- a/torchaudio_augmentations/augmentations/high_low_pass.py
+++ b/torchaudio_augmentations/augmentations/high_low_pass.py
@@ -1,36 +1,36 @@
 import random
 import torch
-
-try:
-    import essentia.standard
-except Exception as e:
-    print("Essentia not found")
+from julius.filters import highpass_filter
+from julius.lowpass import lowpass_filter
 
 
 class HighLowPass(torch.nn.Module):
-    def __init__(self, sample_rate):
+    def __init__(
+        self,
+        sample_rate: int,
+        lowpass_freq_low: int = 2200,
+        lowpass_freq_high: int = 4000,
+        highpass_freq_low: int = 200,
+        highpass_freq_high: int = 1200,
+    ):
         super().__init__()
         self.sample_rate = sample_rate
+        self.lowpass_freq_low = lowpass_freq_low
+        self.lowpass_freq_high = lowpass_freq_high
+        self.highpass_freq_low = highpass_freq_low
+        self.highpass_freq_high = highpass_freq_high
 
     def forward(self, audio):
         highlowband = random.randint(0, 1)
-        try:
-            if highlowband == 0:
-                highpass_freq = random.randint(200, 1200)
-                filt = essentia.standard.HighPass(
-                    cutoffFrequency=highpass_freq, sampleRate=self.sample_rate
-                )
-            elif highlowband == 1:
-                lowpass_freq = random.randint(2200, 4000)
-                filt = essentia.standard.LowPass(
-                    cutoffFrequency=lowpass_freq, sampleRate=self.sample_rate
-                )            
-            # else:
-            #     filt = essentia.standard.BandPass(bandwidth=1000, cutoffFrequency=1500, sampleRate=self.sample_rate)
-            
-            audio = audio.numpy().reshape(-1)
-            audio = filt(audio)
-            audio = torch.from_numpy(audio).reshape(1, -1)
-        except:
-            print("Essentia library not found, skipping HighLowPass augmentation")
+        if highlowband == 0:
+            highpass_freq = random.randint(
+                self.highpass_freq_low, self.highpass_freq_high
+            )
+            cutoff = highpass_freq / self.sample_rate
+            audio = highpass_filter(audio, cutoff=cutoff)
+        elif highlowband == 1:
+            lowpass_freq = random.randint(self.lowpass_freq_low, self.lowpass_freq_high)
+            cutoff = lowpass_freq / self.sample_rate
+            audio = lowpass_filter(audio, cutoff=cutoff)
+
         return audio

--- a/torchaudio_augmentations/augmentations/noise.py
+++ b/torchaudio_augmentations/augmentations/noise.py
@@ -15,12 +15,8 @@ class Noise(torch.nn.Module):
 
     def forward(self, audio):
         std = torch.std(audio)
-        noise_std = random.uniform(
-            self.min_snr * std, self.max_snr * std
-        )
+        noise_std = random.uniform(self.min_snr * std, self.max_snr * std)
 
-        noise = np.random.normal(
-            0.0, noise_std, size=audio.shape
-        ).astype(np.float32)
+        noise = np.random.normal(0.0, noise_std, size=audio.shape).astype(np.float32)
 
         return audio + noise

--- a/torchaudio_augmentations/augmentations/pitch_shift.py
+++ b/torchaudio_augmentations/augmentations/pitch_shift.py
@@ -4,25 +4,26 @@ import augment
 
 
 class PitchShift:
-    def __init__(self, n_samples, sample_rate, pitch_cents_min=-700, pitch_cents_max=700):
+    def __init__(
+        self, n_samples, sample_rate, pitch_cents_min=-700, pitch_cents_max=700
+    ):
         self.n_samples = n_samples
         self.sample_rate = sample_rate
         self.pitch_cents_min = pitch_cents_min
         self.pitch_cents_max = pitch_cents_max
         self.src_info = {"rate": self.sample_rate}
-        self.target_info = {
-            "channels": 1,
-            "length": self.n_samples,
-            "rate": self.sample_rate,
-        }
 
     def __call__(self, audio):
         n_steps = random.randint(self.pitch_cents_min, self.pitch_cents_max)
         effect_chain = augment.EffectChain().pitch(n_steps).rate(self.sample_rate)
 
-        y = effect_chain.apply(
-            audio, src_info=self.src_info, target_info=self.target_info
-        )
+        num_channels = audio.shape[0]
+        target_info = {
+            "channels": num_channels,
+            "length": self.n_samples,
+            "rate": self.sample_rate,
+        }
+        y = effect_chain.apply(audio, src_info=self.src_info, target_info=target_info)
 
         # sox might misbehave sometimes by giving nan/inf if sequences are too short (or silent)
         # and the effect chain includes eg `pitch`
@@ -34,6 +35,6 @@ class PitchShift:
                 y = y[:, audio.shape[1]]
             else:
                 y0 = torch.zeros(1, audio.shape[1])
-                y0[:, :y.shape[1]] = y
+                y0[:, : y.shape[1]] = y
                 y = y0
         return y

--- a/torchaudio_augmentations/augmentations/polarity_inversion.py
+++ b/torchaudio_augmentations/augmentations/polarity_inversion.py
@@ -5,7 +5,7 @@ import random
 class PolarityInversion(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        
+
     def forward(self, audio):
         audio = torch.neg(audio)
         return audio

--- a/torchaudio_augmentations/augmentations/random_resized_crop.py
+++ b/torchaudio_augmentations/augmentations/random_resized_crop.py
@@ -1,5 +1,6 @@
-import torch
 import random
+import torch
+
 
 class RandomResizedCrop(torch.nn.Module):
     def __init__(self, n_samples):

--- a/torchaudio_augmentations/augmentations/reverb.py
+++ b/torchaudio_augmentations/augmentations/reverb.py
@@ -1,6 +1,7 @@
 import augment
 import torch
 
+
 class Reverb(torch.nn.Module):
     def __init__(self, sample_rate, reverberance_min=0, reverberance_max=100, dumping_factor_min=0, dumping_factor_max=100, room_size_min=0, room_size_max=100):
         super().__init__()
@@ -18,13 +19,18 @@ class Reverb(torch.nn.Module):
         }
 
     def forward(self, audio):
-        reverberance = torch.randint(self.reverberance_min, self.reverberance_max, size=(1,)).item()
-        dumping_factor = torch.randint(self.dumping_factor_min, self.dumping_factor_max, size=(1,)).item()
-        room_size = torch.randint(self.room_size_min, self.room_size_max, size=(1,)).item()
+        reverberance = torch.randint(
+            self.reverberance_min, self.reverberance_max, size=(1,)).item()
+        dumping_factor = torch.randint(
+            self.dumping_factor_min, self.dumping_factor_max, size=(1,)).item()
+        room_size = torch.randint(
+            self.room_size_min, self.room_size_max, size=(1,)).item()
+
+        num_channels = audio.shape[0]
         effect_chain = (
             augment.EffectChain()
             .reverb(reverberance, dumping_factor, room_size)
-            .channels(1)
+            .channels(num_channels)
         )
 
         audio = effect_chain.apply(

--- a/torchaudio_augmentations/augmentations/reverb.py
+++ b/torchaudio_augmentations/augmentations/reverb.py
@@ -3,7 +3,16 @@ import torch
 
 
 class Reverb(torch.nn.Module):
-    def __init__(self, sample_rate, reverberance_min=0, reverberance_max=100, dumping_factor_min=0, dumping_factor_max=100, room_size_min=0, room_size_max=100):
+    def __init__(
+        self,
+        sample_rate,
+        reverberance_min=0,
+        reverberance_max=100,
+        dumping_factor_min=0,
+        dumping_factor_max=100,
+        room_size_min=0,
+        room_size_max=100,
+    ):
         super().__init__()
         self.sample_rate = sample_rate
         self.reverberance_min = reverberance_min
@@ -20,11 +29,14 @@ class Reverb(torch.nn.Module):
 
     def forward(self, audio):
         reverberance = torch.randint(
-            self.reverberance_min, self.reverberance_max, size=(1,)).item()
+            self.reverberance_min, self.reverberance_max, size=(1,)
+        ).item()
         dumping_factor = torch.randint(
-            self.dumping_factor_min, self.dumping_factor_max, size=(1,)).item()
+            self.dumping_factor_min, self.dumping_factor_max, size=(1,)
+        ).item()
         room_size = torch.randint(
-            self.room_size_min, self.room_size_max, size=(1,)).item()
+            self.room_size_min, self.room_size_max, size=(1,)
+        ).item()
 
         num_channels = audio.shape[0]
         effect_chain = (

--- a/torchaudio_augmentations/augmentations/reverse.py
+++ b/torchaudio_augmentations/augmentations/reverse.py
@@ -7,4 +7,4 @@ class Reverse(torch.nn.Module):
         super().__init__()
 
     def forward(self, audio):
-        return torch.flip(audio, dims=[0, 1])
+        return torch.flip(audio, dims=[1])

--- a/torchaudio_augmentations/compose.py
+++ b/torchaudio_augmentations/compose.py
@@ -37,6 +37,6 @@ class ComposeMany(Compose):
 
     def __call__(self, x):
         samples = []
-        for n in range(self.num_augmented_samples):
-            samples.append(self.transform(x))
+        for _ in range(self.num_augmented_samples):
+            samples.append(self.transform(x).unsqueeze(dim=0))
         return torch.cat(samples, dim=0)


### PR DESCRIPTION
This adds various unittests and fixes to multi-channel input for Reverb, Pitch, Reverse and HighLowPass filter augmentations.
It also removes Essentia as a dependency, and instead uses `julius` for IRR filtering.